### PR TITLE
Added local documentation

### DIFF
--- a/doc/description.rst
+++ b/doc/description.rst
@@ -1,0 +1,16 @@
+.. _osi-validation:
+
+General description
+======================
+
+The OSI Validator is a validation framework for the field values of OSI messages. It recursively checks the compliance of an OSI message of type ``SensorData``, ``SensorView`` or ``GroundTruth`` according to predefined rules. It was developed due to the need of validation of a huge amount of OSI messages which cannot be validated manually. 
+
+
+
+.. toctree::
+   :maxdepth: 2
+
+   setup
+   usage
+   writing-rules
+   

--- a/doc/howtocontribute.rst
+++ b/doc/howtocontribute.rst
@@ -1,0 +1,33 @@
+Contributors' Guidelines
+==========================
+
+Introduction
+------------
+
+The purpose of this document is to help contributors get started with
+the OSI Validation codebase.
+
+
+Reporting issues
+----------------
+
+The simplest way to contribute to OSI Validation is to report issues that you may
+find with the project on `github <https://github.com/OpenSimulationInterface/osi-validation>`__. Everyone can create issues.
+Always make sure to search the existing issues before reporting a new one.
+Issues may be created to discuss:
+
+- `Feature requests or Ideas <https://github.com/OpenSimulationInterface/osi-validation/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=>`_
+- `Bugs <https://github.com/OpenSimulationInterface/osi-validation/issues/new?assignees=&labels=bug&template=bug_report.md&title=>`_
+- `Questions <https://github.com/OpenSimulationInterface/osi-validation/issues/new?assignees=&labels=question&template=question.md&title=>`_
+- `Other <https://github.com/OpenSimulationInterface/osi-validation/issues/new>`_
+
+If practicable issues should be closed by a referenced pull request or commit (`here <https://help.github.com/en/articles/closing-issues-using-keywords>`_ you can find keywords to close issues automatically). To help developers and maintainers we provide a `pull request template <https://github.com/OpenSimulationInterface/osi-validation/blob/master/.github/pull_request_template.md>`_ which will be generated each time you create a new pull request.
+
+See `here <https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html#our-git-workflow>`_ for more on our git workflow.
+
+Documentation
+----------------
+
+- Documentation changes can be performed by anyone.
+- Consider adding stuff to the `osi-documentation <https://github.com/OpenSimulationInterface/osi-documentation>`_ or directly to the `doc <https://github.com/OpenSimulationInterface/osi-validation/tree/master/doc>`_ folder in the repository.
+- When new changes are made directly to the `osi-documentation <https://github.com/OpenSimulationInterface/osi-documentation>`_ repo the documentation will be rebuild and the new changes can be seen. When making documentation changes in the `doc <https://github.com/OpenSimulationInterface/osi-validation/tree/master/doc>`_ folder of the repository the changes will be visible when the daily chron job of osi-documentation is executed.

--- a/doc/osivalidator.rst
+++ b/doc/osivalidator.rst
@@ -1,0 +1,87 @@
+.. _osivalidator-package:
+
+Validator Reference
+=====================
+
+
+
+osivalidator.linked\_proto\_field module
+----------------------------------------
+
+.. automodule:: osivalidator.linked_proto_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_doxygen\_xml module
+-------------------------------------
+
+.. automodule:: osivalidator.osi_doxygen_xml
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_general\_validator module
+-------------------------------------------
+
+.. automodule:: osivalidator.osi_general_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_id\_manager module
+------------------------------------
+
+.. automodule:: osivalidator.osi_id_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_rules module
+------------------------------
+
+.. automodule:: osivalidator.osi_rules
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_rules\_checker module
+---------------------------------------
+
+.. automodule:: osivalidator.osi_rules_checker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_rules\_implementations module
+-----------------------------------------------
+
+.. automodule:: osivalidator.osi_rules_implementations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_scenario module
+---------------------------------
+
+.. automodule:: osivalidator.osi_scenario
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+osivalidator.osi\_validator\_logger module
+------------------------------------------
+
+.. automodule:: osivalidator.osi_validator_logger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: osivalidator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -1,0 +1,82 @@
+Installation Guide
+====================
+The *OSI Validator* has been developed with **Python 3.6** with virtual environment. It is the only version of Python that is supported now. *OSI Validator* should only be used with **Python 3.6**.
+
+Setup for linux users
+----------------------
+This setup guide is for users who want to just use the validator.
+
+Clone repository osi-validation:
+
+``git clone https://github.com/OpenSimulationInterface/osi-validation.git``
+
+Change directory to osi-validation:
+
+``cd osi-validation``
+
+Clone the repository open-simulation-interface:
+
+``git clone https://github.com/OpenSimulationInterface/open-simulation-interface.git``
+
+Clone repository proto2cpp:
+
+``git clone https://github.com/OpenSimulationInterface/proto2cpp.git``
+
+Install osi-validation into the global root directory:
+
+``sudo pip3 install .``
+
+
+Setup for linux developers
+----------------------------
+This setup guide is for developers who want to contribute to the OSI Validator.
+
+Clone repository osi-validation:
+
+``git clone https://github.com/OpenSimulationInterface/osi-validation.git``
+
+Change directory:
+
+``cd osi-validation``
+
+Clone repository open-simulation-interface:
+
+``git clone https://github.com/OpenSimulationInterface/open-simulation-interface.git``
+
+Clone repository proto2cpp:
+
+``git clone https://github.com/OpenSimulationInterface/proto2cpp.git``
+
+It is best practice to use a virtual environment in python. It has various advantages such as the ability to install modules locally, export a working environment, and execute a Python program in that environment so that you don't mess around with your global python environment. 
+Install virtual environment:
+
+``sudo apt-get install virtualenv``
+
+Create virtual environment:
+
+``virtualenv -p /usr/bin/python3 vpython``
+
+Activate your virtual environment:
+
+``source vpython/bin/activate``
+
+Install open-simulation-interface:
+
+``cd open-simulation-interface; pip install .``
+
+Install osi-validator:
+
+``cd ..; pip install .``
+
+Last step copy ``requirements-osi-3`` to ``vpython/lib/python3.6/site-packages``
+
+``cp -R requirements-osi-3 vpython/lib/python3.6/site-packages/``
+
+
+Setup for windows users
+-------------------------
+In Progress ...
+
+Setup for windows developers
+-----------------------------
+In Progress ...

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1,0 +1,102 @@
+Usage
+=======
+
+Example
+----------------
+After installation you can call the command ``osivalidator`` in your terminal which has the following usage:
+
+.. code-block:: text
+
+    usage: osivalidator [-h] [--rules RULES] --data DATA
+                        [--type {SensorView,GroundTruth,SensorData}]
+                        [--output OUTPUT] [--timesteps TIMESTEPS] [--debug]
+                        [--verbose]
+
+    Validate data defined at the input
+
+    optional arguments:
+    --help, -h                                      Show this help message and exit
+    --rules RULES, -r RULES                         Directory with text files containig rules.
+    --data DATA, -d DATA                            Path to the file with OSI-serialized data.
+    --type {SensorView,GroundTruth,SensorData},     Name of the message type used to serialize data.
+        -t {SensorView,GroundTruth,SensorData}  
+    --output OUTPUT, -o OUTPUT                      Output folder of the log files.
+    --timesteps TIMESTEPS                           Number of timesteps to analyze. If -1, all.
+    --debug                                         Set the debug mode to ON.
+    --verbose                                       Set the verbose mode to ON (display in console).
+
+To run the validation first you need to record an osi-message. Here we already have an osi-message which is called ``osi_message_test.txt``. To validate the osi-message you simply call ``osivalidator`` and provide the path to the stored osi-message which is here in the folder ``osi_message_data``:
+
+.. code-block:: text
+
+    osivalidator --data osi_message_data/osi_message_test.txt
+
+After successfully running the validation the following output is generated:
+
+.. code-block:: text
+
+    Instanciate logger
+    Read data
+    Retrieving message offsets in scenario file until inf...
+    |################################| 172098454/172098454
+    262 messages has been discovered in 0.05367231369018555 s
+    Collect validation rules
+    Caching...
+    Importing messages from scenario file...
+    |################################| 262/262
+    Caching done!
+    |################################| 262/262 [0:00:11]
+
+    Errors (27) 
+    Ranges of timestamps    Message
+    ----------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------
+    [0, 261]                SensorView.sensor_id.is_set(None) does not comply in SensorView
+    [0, 260]                Identifier.value.is_set(None) does not comply in SensorView.sensor_id
+    [0, 261]                SensorView.global_ground_truth.is_set(None) does not comply in SensorView
+    [0, 260]                GroundTruth.host_vehicle_id.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                Identifier.value.is_set(None) does not comply in SensorView.global_ground_truth.host_vehicle_id
+    [0, 260]                GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                GroundTruth.version.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                InterfaceVersion.version_major.is_set(None) does not comply in SensorView.global_ground_truth.version
+    [0, 260]                InterfaceVersion.version_minor.is_set(None) does not comply in SensorView.global_ground_truth.version
+    [0, 260]                InterfaceVersion.version_patch.is_set(None) does not comply in SensorView.global_ground_truth.version
+    [0, 260]                GroundTruth.timestamp.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                Timestamp.seconds.is_set(None) does not comply in SensorView.global_ground_truth.timestamp
+    [0, 260]                Timestamp.nanos.is_set(None) does not comply in SensorView.global_ground_truth.timestamp
+    [0, 260]                GroundTruth.stationary_object.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                GroundTruth.moving_object.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                GroundTruth.lane_boundary.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                GroundTruth.lane.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                GroundTruth.environmental_conditions.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 260]                EnvironmentalConditions.atmospheric_pressure.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                EnvironmentalConditions.temperature.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                EnvironmentalConditions.relative_humidity.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                EnvironmentalConditions.ambient_illumination.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                EnvironmentalConditions.time_of_day.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                EnvironmentalConditions.TimeOfDay.seconds_since_midnight.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions.time_of_day
+    [0, 260]                EnvironmentalConditions.precipitation.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                EnvironmentalConditions.fog.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                Reference unresolved: GroundTruth to MovingObject (ID: 0)
+
+    Warnings (5) 
+    Ranges of timestamps    Message
+    ----------------------  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    [0, 260]                GroundTruth.country_code.is_iso_country_code(None) does not comply in SensorView.global_ground_truth.country_code
+    [0, 260]                EnvironmentalConditions.atmospheric_pressure.is_greater_than_or_equal_to(80000) does not comply in SensorView.global_ground_truth.environmental_conditions.atmospheric_pressure
+    [0, 260]                EnvironmentalConditions.temperature.is_greater_than_or_equal_to(170) does not comply in SensorView.global_ground_truth.environmental_conditions.temperature
+    [0, 260]                GroundTruth.environmental_conditions.is_valid(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 260]                SensorView.global_ground_truth.is_valid(None) does not comply in SensorView.global_ground_truth
+
+The Output is a report of how many errors (here 27) and warnings (here 5) were found in the osi-message according to the defined rules. The rules can be found under the tag ``\rules`` in the \*.proto files from the `osi github <https://github.com/OpenSimulationInterface/open-simulation-interface>`_ or in the `requirements folder <https://github.com/OpenSimulationInterface/osi-validation/tree/master/requirements-osi-3>`_ from osi-validation as \*.yml files (for more information see :ref:`commenting`).  Currently an error is thrown when a field is not set. A warning is thrown when a field is set but do not comply with the defined rules. For each error and warning there is a description on which timestamp it was found, the path to the rule and the path to the osi-message. The general format is:
+
+.. code-block:: text
+
+    Errors (NUMBER_ERRORS) 
+    Ranges of timestamps                Message
+    --------------------------------    --------------------------------------------------------
+    [START_TIMESTAMP, END_TIMESTAMP]    PATH_TO_RULE(VALUE) does not comply in PATH_TO_OSI_FIELD
+
+    Warnings (NUMBER_WARNINGS) 
+    Ranges of timestamps    Message
+    --------------------------------    --------------------------------------------------------
+    [START_TIMESTAMP, END_TIMESTAMP]    PATH_TO_RULE(VALUE) does not comply in PATH_TO_OSI_FIELD

--- a/doc/writing-rules.rst
+++ b/doc/writing-rules.rst
@@ -1,0 +1,80 @@
+.. _how-to-write-rules:
+
+How to write rules
+===================
+
+Folder structure
+-----------------
+
+Currently the rules are contained in ``*.yml`` files in the folder `requirements-osi-3 <https://github.com/OpenSimulationInterface/osi-validation/tree/master/requirements-osi-3>`_. 
+The organization of the files in this folder follows the architecture of OSI for consistency. In the future the rules will be ported directly into the ``*.proto`` files of `OSI <https://github.com/OpenSimulationInterface/open-simulation-interface>`_.
+
+File structure
+---------------
+
+Below you can see an example of the `osi_detectedlane.yml <https://github.com/OpenSimulationInterface/osi-validation/blob/master/requirements-osi-3/osi_detectedlane.yml>`_ rule file for `osi_detectedlane.proto <https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/osi_detectedlane.proto>`_:
+
+.. code-block:: YAML
+
+  DetectedLane:
+    header:
+    CandidateLane:
+      probability:
+        - is_greater_than_or_equal_to: 0
+        - is_less_than_or_equal_to: 1
+      classification:
+
+  DetectedLaneBoundary:
+    header:
+    boundary_line:
+      position:
+
+Each root at the top level represent a root message type ``DetectedLane`` or ``DetectedLaneBoundary``. The children of each root message represent its fields if they are
+not camel-case. For example ``header`` is a field of ``DetectedLane`` or ``header`` and ``boundary_line`` are fields of ``DetectedLaneBoundary``. ``CandidateLane`` is a submessage of the message ``DetectedLane``. Each field has a ``sequence`` (starting with an hyphen ``-``) of rules that apply to that specific field. For example the probability of the message ``CandidateLane`` is between 0 and 1.
+
+
+Rules
+------
+
+The rules can either be with or without any parameters.
+
+::
+
+  is_greater_than_or_equal_to: 0.0
+  is_optional
+  is_equal: 1
+
+In the case a rule has a parameter, it is written as a `mapping` ( a `scalar`
+followed by a colon ":"). What comes after the colon depends on the rule used. For instance, the rule ``is_greater_than_or_equal_to`` accept a double.
+
+The available rules and their usage are explained in the osi-validator class `osi_rules_implementations <https://opensimulationinterface.github.io/osi-documentation/osi-validator/osivalidator.html#module-osivalidator.osi_rules_implementations>`_. See also examples for available rules which can be defined in ``*.yml`` files below:
+
+.. code-block:: python
+    
+    is_greater_than: 1
+    is_greater_than_or_equal_to: 1
+    is_less_than_or_equal_to: 10
+    is_less_than: 2
+    is_equal: 1
+    is_different: 2
+    is_global_unique
+    refers
+    is_iso_country_code
+    first_element: {is_equal: 0.13, is_greater_than: 0.13}
+    last_element: {is_equal: 0.13, is_greater_than: 0.13}
+    is_optional
+    check_if: [{is_equal: 2, is_greater_than: 3, target: this.y}, {do_check: {is_equal: 1, is_less_than: 3}}]
+
+
+Severity
+--------
+
+When an attribute does not comply with a rule, a Warning is throw. An Error
+will be throw if an exclamation mark is written at the end of the verb of a
+rule.
+
+Example
+^^^^^^^
+::
+
+  is_greater_than!: 0


### PR DESCRIPTION
#### Reference to a related issue in the repository
This PR fulfills the requirement from [here](https://github.com/OpenSimulationInterface/osi-documentation/issues/7).

#### Add a description
The PR adds the documentation from [osi-documentation](https://github.com/OpenSimulationInterface/osi-documentation) to the local osi validator repo to keep atomicity and integrity of git repos when changes are made to the documentation. The osi-validation docu will be daily parsed and rebuild by the travis ci of osi-documentation.

#### Mention a member
@pmai @jdsika pls review :)

#### Check the checklist

- [x] My code and comments follow the [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-validation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.