### PR TITLE
Update OSI submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,17 +56,17 @@ script:
     - lzma -d data/small_test.txt.lzma
     - python open-simulation-interface/format/txt2osi.py -d data/small_test.txt
 
-     # Run the validator on decompressed data
-     - osivalidator data/small_test.osi
-     - osivalidator data/small_test.osi -p
-     - osivalidator data/small_test.txt -f separated
-     - osivalidator data/small_test.txt -f separated -p    
- 
-     # Run the validator on decompressed data with parsed rules
-     - osivalidator data/small_test.osi -r rules
-     - osivalidator data/small_test.osi -p -r rules
-     - osivalidator data/small_test.txt -f separated -r rules
-     - osivalidator data/small_test.txt -f separated -p -r rules
+    # Run the validator on decompressed data
+    - osivalidator data/small_test.osi
+    - osivalidator data/small_test.osi -p
+    - osivalidator data/small_test.txt -f separated
+    - osivalidator data/small_test.txt -f separated -p
+
+    # Run the validator on decompressed data with parsed rules
+    - osivalidator data/small_test.osi -r rules
+    - osivalidator data/small_test.osi -p -r rules
+    - osivalidator data/small_test.txt -f separated -r rules
+    - osivalidator data/small_test.txt -f separated -p -r rules
 
     # Compress *.osi and *.txt with lzma
     - lzma -z data/small_test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,26 @@ script:
     # Show validator usage
     - osivalidator -h
 
+    # Convert decompress small_test.txt and convert to small_test.osi
+    - lzma -d data/small_test.txt.lzma
+    - python open-simulation-interface/format/txt2osi.py -d data/small_test.txt
+
+     # Run the validator on decompressed data
+     - osivalidator data/small_test.osi
+     - osivalidator data/small_test.osi -p
+     - osivalidator data/small_test.txt -f separated
+     - osivalidator data/small_test.txt -f separated -p    
+ 
+     # Run the validator on decompressed data with parsed rules
+     - osivalidator data/small_test.osi -r rules
+     - osivalidator data/small_test.osi -p -r rules
+     - osivalidator data/small_test.txt -f separated -r rules
+     - osivalidator data/small_test.txt -f separated -p -r rules
+
+    # Compress *.osi and *.txt with lzma
+    - lzma -z data/small_test.txt
+    - lzma -z data/small_test.osi
+
     # Run validator on a small test with already existing rules
     - osivalidator data/small_test.osi.lzma
     - osivalidator data/small_test.osi.lzma -p
@@ -63,19 +83,3 @@ script:
     - osivalidator data/small_test.osi.lzma -p -r rules
     - osivalidator data/small_test.txt.lzma -f separated -r rules
     - osivalidator data/small_test.txt.lzma -f separated -p -r rules
-
-    # Decompress both traces
-    - lzma -d data/small_test.osi.lzma
-    - lzma -d data/small_test.txt.lzma
-
-    # Run the validator on decompressed data
-    - osivalidator data/small_test.osi
-    - osivalidator data/small_test.osi -p
-    - osivalidator data/small_test.txt -f separated
-    - osivalidator data/small_test.txt -f separated -p    
-
-    # Run the validator on decompressed data with parsed rules
-    - osivalidator data/small_test.osi -r rules
-    - osivalidator data/small_test.osi -p -r rules
-    - osivalidator data/small_test.txt -f separated -r rules
-    - osivalidator data/small_test.txt -f separated -p -r rules

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     - pip install .
 
     # Generate parsed rules
-    python rules2yml.py -d rules
+    - python rules2yml.py -d rules
 
     # Check if rule syntax in osi is correct
     # - python test_cases.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,6 @@ script:
     # Check if rule syntax in osi is correct
     # - python test_cases.py
 
-    # Check rule correctness with unittests
-    - python -m unittest discover tests
-
     # Show validator usage
     - osivalidator -h
 
@@ -71,6 +68,9 @@ script:
     # Compress *.osi and *.txt with lzma
     - lzma -z data/small_test.txt
     - lzma -z data/small_test.osi
+
+    # Check rule correctness with unittests
+    - python -m unittest discover tests
 
     # Run validator on a small test with already existing rules
     - osivalidator data/small_test.osi.lzma

--- a/data/small_test.osi.lzma
+++ b/data/small_test.osi.lzma
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6aa71cd856b6dbfeebee0c9b78a81e339bd3c958a745b3c325c67bbfd370f7d2
-size 130011

--- a/osivalidator/osi_general_validator.py
+++ b/osivalidator/osi_general_validator.py
@@ -167,16 +167,14 @@ def main():
             except Exception as e:
                 print(str(e))
 
-        LOGGER.flush(LOGS)  
+        LOGGER.flush(LOGS)
         MESSAGE_CACHE.clear()
 
     BAR.finish()
-
-    # Grab major OSI version
+    DATA.trace_file.close()
 
     # Synthetize
     LOGGER.synthetize_results_from_sqlite()
-
 
 def close_pool(pool):
     """Cleanly close a pool to free the memory"""

--- a/osivalidator/osi_trace.py
+++ b/osivalidator/osi_trace.py
@@ -53,9 +53,6 @@ class OSITrace:
         self.show_progress = show_progress
         self.retrieved_trace_size = 0
 
-        if path is not None and type_name is not None:
-            self.from_file(path)
-
     # Open and Read text file
     def from_file(self, path, type_name="SensorView", max_index=-1, format_type=None):
         """Import a trace from a file"""
@@ -101,7 +98,7 @@ class OSITrace:
         counter = 0 # Counter is needed to enable correct buffer parsing of serialized messages
 
         # Check if user decided to use buffer
-        if self.buffer_size != 0 and type(self.buffer_size)==int:
+        if self.buffer_size != 0 and type(self.buffer_size) == int:
 
             # Run while the end of file is not reached
             while not eof and message_offset < trace_size:
@@ -114,8 +111,7 @@ class OSITrace:
                     message_length = struct.unpack("<L", serialized_message[message_offset-counter*self.buffer_size:self._int_length+message_offset-counter*self.buffer_size])[0]
 
                     # Get the message offset of the next message
-                    message_offset += message_length + self._int_length               
-
+                    message_offset += message_length + self._int_length
                     self.message_offsets.append(message_offset)
                     self.update_bar(progress_bar, message_offset)
                     before_tell = self.trace_file.tell()
@@ -123,11 +119,10 @@ class OSITrace:
                     after_tell = self.trace_file.tell()
                     eof = self.trace_file.tell() > self.buffer_size * (counter + 1)
                     
-                    # Check if the last INT (length=4) is found and then exit
-                    if after_tell - before_tell == self._int_length:
+                    # Check if reached end of file
+                    if self.trace_file.tell() == trace_size:
                         self.retrieved_trace_size = self.message_offsets[-1]
-                        self.message_offsets.pop() # Remove the last element since after that there is no message coming  
-                        self.trace_file.seek(trace_size) # Set the cursor to the end of the file
+                        self.message_offsets.pop() # Remove the last element since after that there is no message coming
                         break
 
                 while eof:

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
         install_requires=[
             'iso3166',
             'ruamel.yaml',
+            'PyYaml',
             'asteval',
             'sphinx_rtd_theme',
             'recommonmark',


### PR DESCRIPTION
#### Reference to a related issue in the repository
This PR does some minor updates to the PR [here](https://github.com/OpenSimulationInterface/osi-validation/pull/23) and updates the osi submodule with rules.

#### Description
This PR updates the OSI submodule so it can parse the rules from the comments and fixes a typo in travis ci. I also added PyYaml to the dependecies of osi-validator since it is needed to generate yml files.

**Change notes:**
- fixed typo in travis ci
- added PyYaml to validator dependecies
- updated osi submodule so it points to the commit with rules so that the validator can use them
- added test for txt2osi, so only a *.txt file is uploaded and converted and validated hence removing the small_test.osi.lzma
- added line for closing the trace file in `osi_general-validator.py`
- removed line in osi_trace.py where it was opening the file twice
- added better if statement to identify end of file (`self.trace_file.tell() == trace_size`)


#### Mention a member
@jdsika pls review and merge thanks :)

#### Check the checklist

- [x] My code and comments follow the [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-validation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.