### PR TITLE
Usage update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,14 +61,14 @@ script:
     # Run the validator on decompressed data
     - osivalidator data/small_test.osi
     - osivalidator data/small_test.osi -p
-    - osivalidator data/small_test.txt -f separated
-    - osivalidator data/small_test.txt -f separated -p
+    - osivalidator data/small_test.txt
+    - osivalidator data/small_test.txt -p
 
     # Run the validator on decompressed data with parsed rules
     - osivalidator data/small_test.osi -r rules
     - osivalidator data/small_test.osi -p -r rules
-    - osivalidator data/small_test.txt -f separated -r rules
-    - osivalidator data/small_test.txt -f separated -p -r rules
+    - osivalidator data/small_test.txt -r rules
+    - osivalidator data/small_test.txt -p -r rules
 
     # Compress *.osi and *.txt with lzma
     - lzma -z data/small_test.txt
@@ -80,11 +80,11 @@ script:
     # Run validator on a small test with already existing rules
     - osivalidator data/small_test.osi.lzma
     - osivalidator data/small_test.osi.lzma -p
-    - osivalidator data/small_test.txt.lzma -f separated
-    - osivalidator data/small_test.txt.lzma -f separated -p
+    - osivalidator data/small_test.txt.lzma
+    - osivalidator data/small_test.txt.lzma -p
 
     # Run validator on a small test with parsed rules
     - osivalidator data/small_test.osi.lzma -r rules
     - osivalidator data/small_test.osi.lzma -p -r rules
-    - osivalidator data/small_test.txt.lzma -f separated -r rules
-    - osivalidator data/small_test.txt.lzma -f separated -p -r rules
+    - osivalidator data/small_test.txt.lzma -r rules
+    - osivalidator data/small_test.txt.lzma -p -r rules

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ script:
     # Show validator usage
     - osivalidator -h
 
+    # Check rule correctness with unittests
+    - python -m unittest discover tests
+
     # Convert decompress small_test.txt and convert to small_test.osi
     - lzma -d data/small_test.txt.lzma
     - python open-simulation-interface/format/txt2osi.py -d data/small_test.txt
@@ -73,9 +76,6 @@ script:
     # Compress *.osi and *.txt with lzma
     - lzma -z data/small_test.txt
     - lzma -z data/small_test.osi
-
-    # Check rule correctness with unittests
-    - python -m unittest discover tests
 
     # Run validator on a small test with already existing rules
     - osivalidator data/small_test.osi.lzma

--- a/README.md
+++ b/README.md
@@ -53,12 +53,19 @@ $ git clone https://github.com/OpenSimulationInterface/osi-validation.git
 $ cd osi-validation
 $ git submodule update --init
 $ sudo apt-get install virtualenv
-$ virtualenv -p /usr/bin/python3 vpython
-$ source vpython/bin/activate
-$ cd open-simulation-interface
-$ pip install .
-$ cd ..
-$ pip install .
+$ virtualenv -p /usr/bin/python3 venv
+$ source venv/bin/activate
+(venv) $ cd open-simulation-interface
+(venv) $ pip install .
+(venv) $ cd ..
+(venv) $ pip install .
+```
+
+##### Compile (optional)
+
+```bash
+(venv) $ pip install pyinstaller
+(venv) $ pyinstaller osivalidator/osi_general_validator.py --onefile
 ```
 
 #### Global

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -8,28 +8,63 @@ This setup guide is for users who want to just use the validator.
 
 Clone the repository osi-validation:
 
-``git clone https://github.com/OpenSimulationInterface/osi-validation.git``
+.. code-block:: bash
+
+    git clone https://github.com/OpenSimulationInterface/osi-validation.git
 
 Change directory to osi-validation:
 
-``cd osi-validation``
+.. code-block:: bash
+
+    cd osi-validation
 
 Clone the submodules:
 
-``git submodule update --init``
+.. code-block:: bash
+
+    git submodule update --init
 
 Install the open-simulation-interface:
 
-``cd open-simulation-interface; pip install .``
+.. code-block:: bash
+
+    cd open-simulation-interface
+    pip install .
 
 Install osi-validation into the global root directory:
 
-``cd ..; sudo pip3 install .``
+.. code-block:: bash
+
+    cd ..; sudo pip3 install .
 
 Now you can run the validator on an example trace file (``trace.osi``) by calling:
 
-``osivalidator -d trace.osi``
+.. code-block:: bash
 
+    osivalidator -d trace.osi
+
+OSI Validator Binary
+~~~~~~~~~~~~~~~~~~~~~
+After the installation of all the dependencies it is possible to compile the osi-validator into one binary file (size ~ 9.1 Mb) for easier distribution and usage.
+For that we use `pyinstaller <https://www.pyinstaller.org/>`_:
+
+.. code-block:: bash
+
+    pip install pyinstaller
+    pyinstaller osivalidator/osi_general_validator.py --onefile
+
+After the compilation you can find the binary in the ``dist`` directory. You can use the binary the normal way you would use the command line interface:
+
+.. code-block:: bash
+
+    ./dist/osi_general_validator -h
+
+Make sure to provide the path to the rules when validating trace files to avoid path errors:
+
+.. code-block:: bash
+
+    python rules2yml.py # Parse and generate rules folder
+    ./dist/osi_general_validator -r rules data/small_test.txt.lzma
 
 Setup for linux developers
 ----------------------------
@@ -37,36 +72,53 @@ This setup guide is for developers who want to contribute to the OSI Validator.
 
 Clone repository osi-validation:
 
-``git clone https://github.com/OpenSimulationInterface/osi-validation.git``
+.. code-block:: bash
+
+    git clone https://github.com/OpenSimulationInterface/osi-validation.git
 
 Change directory:
 
-``cd osi-validation``
+.. code-block:: bash
+
+    cd osi-validation
 
 Clone the submodules:
 
-``git submodule update --init``
+.. code-block:: bash
+
+    git submodule update --init
 
 It is best practice to use a virtual environment in python. It has various advantages such as the ability to install modules locally, export a working environment, and execute a Python program in that environment so that you don't mess around with your global python environment. 
 Install virtual environment:
 
-``sudo apt-get install virtualenv``
+.. code-block:: bash
+
+    sudo apt-get install virtualenv
 
 Create virtual environment:
 
-``virtualenv -p /usr/bin/python3 vpython``
+.. code-block:: bash
+
+    virtualenv -p /usr/bin/python3 vpython
 
 Activate your virtual environment:
 
-``source vpython/bin/activate``
+.. code-block:: bash
+
+    source vpython/bin/activate
 
 Install open-simulation-interface:
 
-``cd open-simulation-interface; pip install .``
+.. code-block:: bash
+
+    cd open-simulation-interface
+    pip install .
 
 Now you can run the validator on an example trace file (``trace.osi``) by calling:
 
-``python osivalidator/osi_general_validator.py -d trace.osi``
+.. code-block:: bash
+
+    python osivalidator/osi_general_validator.py -d trace.osi
 
 The advantage to call the osi-validator this way for developers is that you do not need to reinstall the application when you made changes to the code.
 

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -99,13 +99,13 @@ Create virtual environment:
 
 .. code-block:: bash
 
-    virtualenv -p /usr/bin/python3 vpython
+    virtualenv -p /usr/bin/python3 venv
 
 Activate your virtual environment:
 
 .. code-block:: bash
 
-    source vpython/bin/activate
+    source venv/bin/activate
 
 Install open-simulation-interface:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -43,7 +43,8 @@ After installation you can call the command ``osivalidator`` in your terminal wh
                             buffering at all.
 
 To run the validation first you need an OSI trace file which consists of multiple OSI messages. 
-In the directory ``data`` we already have two OSI trace files provided which are called ``small_test.osi.lzma`` (a `lzma <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm>`_ compressed trace file with length separation of OSI messages) and a ``small_test.txt.lzma`` (a `lzma <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm>`_ compressed trace file with the ``$$__$$`` separator which in future will be depracted. Use the ``txt2osi.py`` of the OSI repo in the format directory to convert from ``*.txt`` to ``*.osi`` files or from ``*.txt.lzma`` to ``*.osi.lzma``). See usage below:
+In the directory ``data`` of the repository we already provide an example trace file which is called ``small_test.txt.lzma`` (a `lzma <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm>`_ compressed trace file with the ``$$__$$`` separator which can/should be converted into an ``*.osi`` file). For decompressing lzma compressed files on linux machines run ``lzma -d data/small_test.txt.lzma``. 
+Use the `txt2osi.py <https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/format/txt2osi.py>`_ of the OSI repo in the format directory to convert from ``*.txt`` to ``*.osi`` files or from ``*.txt.lzma`` to ``*.osi.lzma``). See usage below:
 
 .. code-block:: bash
 
@@ -67,73 +68,132 @@ To validate the trace files you simply call ``osivalidator`` and provide the pat
 .. code-block:: bash
 
     osivalidator --data data/small_test.osi.lzma
-    osivalidator --data data/small_test.txt.lzma -f separated
+    osivalidator --data data/small_test.txt.lzma
 
 You can also validate the traces in parallel to increase the speed of the validation by providing ``-p`` flag:
 
 .. code-block:: bash
 
     osivalidator --data data/small_test.osi.lzma -p
-    osivalidator --data data/small_test.txt.lzma -f separated -p
+    osivalidator --data data/small_test.txt.lzma -p
+
+To validate trace files with rules defined in the comments of ``*.proto`` files in the open-simulation-interface repository first you need to generate them and then specify them:
+
+.. code-block:: bash
+
+    python rules2yml.py # Generates the rule directory
+    osivalidator -r rules data/small_test.txt.lzma -p
 
 
 After successfully running the validation the following output is generated:
 
+.. note::
+
+    For demonstration purposes a more complex trace file was used in this example.
+
 .. code-block:: bash
 
-    Instanciate logger
-    Read data
-    Retrieving message offsets in scenario file until inf...
-    |################################| 172098454/172098454
-    262 messages has been discovered in 0.05367231369018555 s
-    Collect validation rules
-    Caching...
-    Importing messages from scenario file...
-    |################################| 262/262
+    Instantiate logger ...
+    Reading data ...
+    Retrieving messages in osi trace file until 3606600 ...
+    |################################| 3606600/3606600
+    1500 messages has been discovered in 0.03429770469665527 s
+    Collect validation rules ...
+
+    Caching ...
+    Importing messages from trace file ...
+    |################################| 500/500
     Caching done!
-    |################################| 262/262 [0:00:11]
+    |##########                      | 500/1500 [0:00:02]
+    Closed pool!
 
-    Errors (27) 
+    Caching ...
+    Importing messages from trace file ...
+    |################################| 500/500
+    Caching done!
+    |#####################           | 1000/1500 [0:00:07]
+    Closed pool!
+
+    Caching ...
+    Importing messages from trace file ...
+    |################################| 500/500
+    Caching done!
+    |################################| 1500/1500 [0:00:13]
+    Closed pool!
+
+
+    Errors (57) 
+    Ranges of timestamps                Message
+    ----------------------------------  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    [0, 1499]                           SensorView.sensor_id.is_set(None) does not comply in SensorView
+    [0, 498], [500, 998], [1000, 1498]  SensorView.host_vehicle_id.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.version.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.mounting_position.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.mounting_position_rmse.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.host_vehicle_data.is_set(None) does not comply in SensorView
+    [0, 1499]                           GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.version.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.stationary_object.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           MovingObject.vehicle_attributes.check_if.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 1499]                           MovingObject.vehicle_attributes.check_if([{'is_equal_to': 2, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 1499]                           MovingObject.vehicle_attributes.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 1499]                           MovingObject.VehicleClassification.trailer_id.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
+    [0, 1499]                           MovingObject.VehicleClassification.light_state.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
+    [0, 1499]                           MovingObject.VehicleClassification.has_trailer.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
+    [0, 1499]                           MovingObject.vehicle_classification.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
+    [0, 1499]                           BaseMoving.orientation.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 1499]                           BaseMoving.acceleration.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 1499]                           BaseMoving.orientation_rate.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 1499]                           BaseMoving.orientation_acceleration.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 1499]                           BaseMoving.base_polygon.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 1499]                           MovingObject.base.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 1499]                           MovingObject.assigned_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 1499]                           MovingObject.model_reference.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 1499]                           GroundTruth.moving_object.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 1499]                           GroundTruth.traffic_sign.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.traffic_light.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.road_marking.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           LaneBoundary.boundary_line.first_element({'height': [{'is_equal_to': 0, 'target': 'this.height'}]}) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
+    [0, 1499]                           LaneBoundary.boundary_line.last_element({'height': [{'is_equal_to': 0, 'target': 'this.height'}]}) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
+    [0, 1499]                           LaneBoundary.BoundaryPoint.width.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
+    [0, 1499]                           LaneBoundary.BoundaryPoint.height.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
+    [0, 1499]                           LaneBoundary.boundary_line.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
+    [0, 1499]                           LaneBoundary.classification.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary
+    [0, 1499]                           GroundTruth.lane_boundary.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary
+    [0, 1499]                           Lane.Classification.left_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.right_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.right_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.left_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.free_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.type.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.is_host_vehicle_lane.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.centerline_is_driving_direction.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.lane_pairing.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.Classification.road_condition.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           Lane.classification.is_valid(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 1499]                           GroundTruth.lane.is_valid(None) does not comply in SensorView.global_ground_truth.lane
+    [0, 1499]                           GroundTruth.occupant.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.environmental_conditions.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.proj_string.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           GroundTruth.map_reference.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           SensorView.global_ground_truth.is_valid(None) does not comply in SensorView.global_ground_truth
+    [0, 1499]                           SensorView.generic_sensor_view.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.radar_sensor_view.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.lidar_sensor_view.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.camera_sensor_view.is_set(None) does not comply in SensorView
+    [0, 1499]                           SensorView.ultrasonic_sensor_view.is_set(None) does not comply in SensorView
+
+    Warnings (3) 
     Ranges of timestamps    Message
-    ----------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------
-    [0, 261]                SensorView.sensor_id.is_set(None) does not comply in SensorView
-    [0, 260]                Identifier.value.is_set(None) does not comply in SensorView.sensor_id
-    [0, 261]                SensorView.global_ground_truth.is_set(None) does not comply in SensorView
-    [0, 260]                GroundTruth.host_vehicle_id.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                Identifier.value.is_set(None) does not comply in SensorView.global_ground_truth.host_vehicle_id
-    [0, 260]                GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                GroundTruth.version.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                InterfaceVersion.version_major.is_set(None) does not comply in SensorView.global_ground_truth.version
-    [0, 260]                InterfaceVersion.version_minor.is_set(None) does not comply in SensorView.global_ground_truth.version
-    [0, 260]                InterfaceVersion.version_patch.is_set(None) does not comply in SensorView.global_ground_truth.version
-    [0, 260]                GroundTruth.timestamp.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                Timestamp.seconds.is_set(None) does not comply in SensorView.global_ground_truth.timestamp
-    [0, 260]                Timestamp.nanos.is_set(None) does not comply in SensorView.global_ground_truth.timestamp
-    [0, 260]                GroundTruth.stationary_object.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                GroundTruth.moving_object.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                GroundTruth.lane_boundary.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                GroundTruth.lane.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                GroundTruth.environmental_conditions.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 260]                EnvironmentalConditions.atmospheric_pressure.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                EnvironmentalConditions.temperature.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                EnvironmentalConditions.relative_humidity.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                EnvironmentalConditions.ambient_illumination.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                EnvironmentalConditions.time_of_day.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                EnvironmentalConditions.TimeOfDay.seconds_since_midnight.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions.time_of_day
-    [0, 260]                EnvironmentalConditions.precipitation.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                EnvironmentalConditions.fog.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                Reference unresolved: GroundTruth to MovingObject (ID: 0)
+    ----------------------  ----------------------------------------------------------------------
+    [0, 1499]               Several objects of type MovingObject, LaneBoundary, Lane have the ID 0
+    [0, 1499]               Several objects of type MovingObject, LaneBoundary, Lane have the ID 1
+    [0, 1499]               Several objects of type LaneBoundary, Lane have the ID 2
 
-    Warnings (5) 
-    Ranges of timestamps    Message
-    ----------------------  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    [0, 260]                GroundTruth.country_code.is_iso_country_code(None) does not comply in SensorView.global_ground_truth.country_code
-    [0, 260]                EnvironmentalConditions.atmospheric_pressure.is_greater_than_or_equal_to(80000) does not comply in SensorView.global_ground_truth.environmental_conditions.atmospheric_pressure
-    [0, 260]                EnvironmentalConditions.temperature.is_greater_than_or_equal_to(170) does not comply in SensorView.global_ground_truth.environmental_conditions.temperature
-    [0, 260]                GroundTruth.environmental_conditions.is_valid(None) does not comply in SensorView.global_ground_truth.environmental_conditions
-    [0, 260]                SensorView.global_ground_truth.is_valid(None) does not comply in SensorView.global_ground_truth
 
-The Output is a report of how many errors (here 27) and warnings (here 5) were found in the osi-message according to the defined rules. The rules can be found under the tag ``\rules`` in the \*.proto files from the `osi github <https://github.com/OpenSimulationInterface/open-simulation-interface>`_ or in the `requirements folder <https://github.com/OpenSimulationInterface/osi-validation/tree/master/requirements-osi-3>`_ from osi-validation as \*.yml files (for more information see :ref:`commenting`).  Currently an error is thrown when a field is not set. A warning is thrown when a field is set but do not comply with the defined rules. For each error and warning there is a description on which timestamp it was found, the path to the rule and the path to the osi-message. The general format is:
+The Output is a report of how many errors (here 57) and warnings (here 3) were found in the osi-message according to the defined rules in your specified rules directory. The rules can be found under the tag ``\rules`` in the \*.proto files from the `osi github <https://github.com/OpenSimulationInterface/open-simulation-interface>`_ or in the `requirements folder <https://github.com/OpenSimulationInterface/osi-validation/tree/master/requirements-osi-3>`_ from osi-validation as \*.yml files (for more information see :ref:`commenting`).
+
+Currently an error is thrown when a field is not valid. A warning is thrown when a field is valid and set but does not comply with the defined rules. For each error and warning there is a description on which timestamp it was found, the path to the rule and the path to the osi-message. The general format is:
 
 .. code-block:: bash
 
@@ -146,3 +206,5 @@ The Output is a report of how many errors (here 27) and warnings (here 5) were f
     Ranges of timestamps    Message
     --------------------------------    --------------------------------------------------------
     [START_TIMESTAMP, END_TIMESTAMP]    PATH_TO_RULE(VALUE) does not comply in PATH_TO_OSI_FIELD
+
+The rules to the fileds are applied in a recursive fashion. 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -89,111 +89,137 @@ After successfully running the validation the following output is generated:
 
 .. note::
 
-    For demonstration purposes a more complex trace file was used in this example.
+    For demonstration purposes a more complex trace file with 2718 OSI message was used in this example.
 
 .. code-block:: bash
 
     Instantiate logger ...
     Reading data ...
-    Retrieving messages in osi trace file until 3606600 ...
-    |################################| 3606600/3606600
-    1500 messages has been discovered in 0.03429770469665527 s
+    Retrieving messages in osi trace file until 1314997975 ...
+    |################################| 1314997975/1314997975
+    2718 messages has been discovered in 0.8990724086761475 s
     Collect validation rules ...
 
     Caching ...
     Importing messages from trace file ...
     |################################| 500/500
     Caching done!
-    |##########                      | 500/1500 [0:00:02]
+    |#####                           | 500/2718 [0:04:07]
     Closed pool!
 
     Caching ...
     Importing messages from trace file ...
     |################################| 500/500
     Caching done!
-    |#####################           | 1000/1500 [0:00:07]
+    |###########                     | 1000/2718 [0:07:06]
     Closed pool!
 
     Caching ...
     Importing messages from trace file ...
     |################################| 500/500
     Caching done!
-    |################################| 1500/1500 [0:00:13]
+    |#################               | 1500/2718 [0:09:09]
+    Closed pool!
+
+    Caching ...
+    Importing messages from trace file ...
+    |################################| 500/500
+    Caching done!
+    |#######################         | 2000/2718 [0:12:34]
+    Closed pool!
+
+    Caching ...
+    Importing messages from trace file ...
+    |################################| 500/500
+    Caching done!
+    |#############################   | 2500/2718 [0:17:05]
+    Closed pool!
+
+    Caching ...
+    Importing messages from trace file ...
+    |################################| 218/218
+    Caching done!
+    |################################| 2718/2718 [0:17:54]
     Closed pool!
 
 
-    Errors (57) 
-    Ranges of timestamps                Message
-    ----------------------------------  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    [0, 1499]                           SensorView.sensor_id.is_set(None) does not comply in SensorView
-    [0, 498], [500, 998], [1000, 1498]  SensorView.host_vehicle_id.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.version.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.mounting_position.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.mounting_position_rmse.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.host_vehicle_data.is_set(None) does not comply in SensorView
-    [0, 1499]                           GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.version.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.stationary_object.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           MovingObject.vehicle_attributes.check_if.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
-    [0, 1499]                           MovingObject.vehicle_attributes.check_if([{'is_equal_to': 2, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.moving_object
-    [0, 1499]                           MovingObject.vehicle_attributes.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
-    [0, 1499]                           MovingObject.VehicleClassification.trailer_id.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
-    [0, 1499]                           MovingObject.VehicleClassification.light_state.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
-    [0, 1499]                           MovingObject.VehicleClassification.has_trailer.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
-    [0, 1499]                           MovingObject.vehicle_classification.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
-    [0, 1499]                           BaseMoving.orientation.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
-    [0, 1499]                           BaseMoving.acceleration.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
-    [0, 1499]                           BaseMoving.orientation_rate.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
-    [0, 1499]                           BaseMoving.orientation_acceleration.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
-    [0, 1499]                           BaseMoving.base_polygon.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
-    [0, 1499]                           MovingObject.base.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.base
-    [0, 1499]                           MovingObject.assigned_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
-    [0, 1499]                           MovingObject.model_reference.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
-    [0, 1499]                           GroundTruth.moving_object.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object
-    [0, 1499]                           GroundTruth.traffic_sign.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.traffic_light.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.road_marking.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           LaneBoundary.boundary_line.first_element({'height': [{'is_equal_to': 0, 'target': 'this.height'}]}) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
-    [0, 1499]                           LaneBoundary.boundary_line.last_element({'height': [{'is_equal_to': 0, 'target': 'this.height'}]}) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
-    [0, 1499]                           LaneBoundary.BoundaryPoint.width.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
-    [0, 1499]                           LaneBoundary.BoundaryPoint.height.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
-    [0, 1499]                           LaneBoundary.boundary_line.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary.boundary_line
-    [0, 1499]                           LaneBoundary.classification.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary
-    [0, 1499]                           GroundTruth.lane_boundary.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary
-    [0, 1499]                           Lane.Classification.left_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.right_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.right_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.left_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.free_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.type.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.is_host_vehicle_lane.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.centerline_is_driving_direction.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.lane_pairing.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.Classification.road_condition.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           Lane.classification.is_valid(None) does not comply in SensorView.global_ground_truth.lane.classification
-    [0, 1499]                           GroundTruth.lane.is_valid(None) does not comply in SensorView.global_ground_truth.lane
-    [0, 1499]                           GroundTruth.occupant.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.environmental_conditions.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.proj_string.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           GroundTruth.map_reference.is_set(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           SensorView.global_ground_truth.is_valid(None) does not comply in SensorView.global_ground_truth
-    [0, 1499]                           SensorView.generic_sensor_view.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.radar_sensor_view.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.lidar_sensor_view.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.camera_sensor_view.is_set(None) does not comply in SensorView
-    [0, 1499]                           SensorView.ultrasonic_sensor_view.is_set(None) does not comply in SensorView
+    Errors (55) 
+    Ranges of timestamps                      Message
+    ----------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    [0, 2717]                                 SensorView.host_vehicle_id.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.version.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.timestamp.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.mounting_position.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.mounting_position_rmse.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.host_vehicle_data.is_set(None) does not comply in SensorView
+    [0, 498], [500, 998], [1000, 1498],       GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
+    [1500, 1998], [2000, 2498], [2500, 2716]
+    [0, 2717]                                 BaseStationary.base_polygon.is_set(None) does not comply in SensorView.global_ground_truth.stationary_object.base
+    [0, 2717]                                 StationaryObject.base.is_valid(None) does not comply in SensorView.global_ground_truth.stationary_object.base
+    [0, 2717]                                 StationaryObject.model_reference.is_set(None) does not comply in SensorView.global_ground_truth.stationary_object
+    [0, 2717]                                 GroundTruth.stationary_object.is_valid(None) does not comply in SensorView.global_ground_truth.stationary_object
+    [0, 2717]                                 MovingObject.VehicleAttributes.number_wheels.is_greater_than_or_equal_to(1) does not comply in SensorView.global_ground_truth.moving_object.vehicle_attributes.number_wheels
+    [0, 2717]                                 MovingObject.vehicle_attributes.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_attributes
+    [0, 2717]                                 MovingObject.VehicleClassification.LightState.emergency_vehicle_illumination.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification.light_state
+    [0, 2717]                                 MovingObject.VehicleClassification.LightState.service_vehicle_illumination.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification.light_state
+    [0, 2717]                                 MovingObject.VehicleClassification.light_state.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification.light_state
+    [0, 2717]                                 MovingObject.vehicle_classification.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
+    [0, 2717]                                 BaseMoving.orientation_acceleration.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 2717]                                 BaseMoving.base_polygon.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 2717]                                 MovingObject.base.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.base
+    [0, 2717]                                 MovingObject.model_reference.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 2717]                                 GroundTruth.moving_object.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 2717]                                 GroundTruth.traffic_sign.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.traffic_light.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.road_marking.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 LaneBoundary.Classification.limiting_structure_id.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary.classification
+    [0, 2717]                                 LaneBoundary.classification.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary.classification
+    [0, 2717]                                 GroundTruth.lane_boundary.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary
+    [0, 2717]                                 Lane.Classification.right_adjacent_lane_id.check_if.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.right_adjacent_lane_id.check_if([{'is_different_to': 4, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.right_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.free_lane_boundary_id.check_if.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.free_lane_boundary_id.check_if([{'is_different_to': 4, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.free_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.lane_pairing.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.classification.is_valid(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.left_adjacent_lane_id.check_if.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.left_adjacent_lane_id.check_if([{'is_different_to': 4, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 Lane.Classification.left_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 GroundTruth.lane.is_valid(None) does not comply in SensorView.global_ground_truth.lane
+    [0, 2717]                                 GroundTruth.occupant.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 EnvironmentalConditions.atmospheric_pressure.is_greater_than_or_equal_to(80000) does not comply in SensorView.global_ground_truth.environmental_conditions.atmospheric_pressure
+    [0, 2717]                                 EnvironmentalConditions.temperature.is_greater_than_or_equal_to(170) does not comply in SensorView.global_ground_truth.environmental_conditions.temperature
+    [0, 2717]                                 EnvironmentalConditions.unix_timestamp.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 498], [500, 998], [1000, 1498],       EnvironmentalConditions.fog.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [1500, 1998], [2000, 2498], [2500, 2716]
+    [0, 2717]                                 GroundTruth.environmental_conditions.is_valid(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+    [0, 2717]                                 GroundTruth.proj_string.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.map_reference.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 SensorView.global_ground_truth.is_valid(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 SensorView.generic_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.radar_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.lidar_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.camera_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.ultrasonic_sensor_view.is_set(None) does not comply in SensorView
+    499, 999, 1499, 1999, 2499, 2717          GroundTruth.country_code.is_iso_country_code(None) does not comply in SensorView.global_ground_truth.country_code
 
-    Warnings (3) 
+    Warnings (7) 
     Ranges of timestamps    Message
     ----------------------  ----------------------------------------------------------------------
-    [0, 1499]               Several objects of type MovingObject, LaneBoundary, Lane have the ID 0
-    [0, 1499]               Several objects of type MovingObject, LaneBoundary, Lane have the ID 1
-    [0, 1499]               Several objects of type LaneBoundary, Lane have the ID 2
+    [0, 2717]               Several objects of type SensorView, MovingObject have the ID 0
+    [513, 641]              Several objects of type StationaryObject, MovingObject have the ID 555
+    513, [571, 641]         Several objects of type StationaryObject, MovingObject have the ID 454
+    [504, 512]              Several objects of type StationaryObject, MovingObject have the ID 444
+    [642, 770]              Several objects of type StationaryObject, MovingObject have the ID 666
+    [643, 749]              Several objects of type StationaryObject, MovingObject have the ID 667
+    [642, 770]              Several objects of type StationaryObject, MovingObject have the ID 668
 
 
-The Output is a report of how many errors (here 57) and warnings (here 3) were found in the osi-message according to the defined rules in your specified rules directory. The rules can be found under the tag ``\rules`` in the \*.proto files from the `osi github <https://github.com/OpenSimulationInterface/open-simulation-interface>`_ or in the `requirements folder <https://github.com/OpenSimulationInterface/osi-validation/tree/master/requirements-osi-3>`_ from osi-validation as \*.yml files (for more information see :ref:`commenting`).
 
-Currently an error is thrown when a field is not valid. A warning is thrown when a field is valid and set but does not comply with the defined rules. For each error and warning there is a description on which timestamp it was found, the path to the rule and the path to the osi-message. The general format is:
+The Output is a report of how many errors (here 55) and warnings (here 7) were found in the osi-message according to the defined rules in your specified rules directory. The rules can be found under the tag ``\rules`` in the \*.proto files from the `osi github <https://github.com/OpenSimulationInterface/open-simulation-interface>`_ or in the `requirements folder <https://github.com/OpenSimulationInterface/osi-validation/tree/master/requirements-osi-3>`_ from osi-validation as \*.yml files (for more information see :ref:`commenting`).
+
+Currently an error is thrown when a message is not valid or the fields inside the message are not set. A warning is thrown everything concerning ids. For each error and warning there is a description on which timestamp it was found, the path to the rule and the path to the osi-message is provided. The general format is:
 
 .. code-block:: bash
 
@@ -207,4 +233,177 @@ Currently an error is thrown when a field is not valid. A warning is thrown when
     --------------------------------    --------------------------------------------------------
     [START_TIMESTAMP, END_TIMESTAMP]    PATH_TO_RULE(VALUE) does not comply in PATH_TO_OSI_FIELD
 
-The rules to the fileds are applied in a recursive fashion. 
+Understanding Validation Ouput
+-------------------------------
+For easier understanding of the validation output let us use the example above and describe the meaning of the lines.
+First of all one should know that the rules to the fields are checked in a `depth-first-search <https://en.wikipedia.org/wiki/Depth-first_search>`_ (DFS) traversal manner. 
+The validation starts with the ``SensorView`` Node and goes in depth if the message is set. For example the messages below are checked but do not go further in depth because they are not set (indicated by ``is_set(None)``):
+
+.. code-block:: bash
+
+    [0, 2717]                                 SensorView.host_vehicle_id.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.version.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.timestamp.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.mounting_position.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.mounting_position_rmse.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.host_vehicle_data.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.generic_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.radar_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.lidar_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.camera_sensor_view.is_set(None) does not comply in SensorView
+    [0, 2717]                                 SensorView.ultrasonic_sensor_view.is_set(None) does not comply in SensorView
+
+Since the ``GlobalGroundTruth`` in ``SensorView`` is set (``SensorView.global_ground_truth``) the next check is a test if it is valid. 
+A message is valid when all the fields in all the submessages comply to the rules. Hence the check for valid fields is performed recursively.
+The validation output prints a non valid message (indicated by ``is_valid(None)``):
+
+.. code-block:: bash
+
+    [0, 2717]                                 SensorView.global_ground_truth.is_valid(None) does not comply in SensorView.global_ground_truth
+
+This is because at least one message field does not comply to the rules like:
+
+.. code-block:: bash
+
+    [0, 498], [500, 998], [1000, 1498],       GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
+    [1500, 1998], [2000, 2498], [2500, 2716]
+
+In the rules (``osi_groundtruth.yml``) we defined (\*.yml files follow the same structure as \*.proto file in OSI):
+
+.. code-block:: yaml
+
+    GroundTruth:
+        country_code:
+            - is_iso_country_code:
+
+This means if the field is not in the `ISO country code <https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes>`_ format an error will be thrown making ``SensorView.global_ground_truth`` invalid because ``SensorView.global_ground_truth.country_code`` is not set correctly. The incorrectness is appearing in the intervals between message frame 0 and message frame 498 but not in message frame 499. That is why you see split frame messages like this [0, 498], [500, 998].
+Note that ``GroundTruth.country_code`` refers to the same path as ``SensorView.global_ground_truth.country_code``. 
+The SensorView part is cut due to better readability.
+
+In the output there are more message fields which are not set on the ``GroundTruth`` level making it invalid:
+
+.. code-block:: bash
+
+    [0, 2717]                                 GroundTruth.proj_string.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.map_reference.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.occupant.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.traffic_sign.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.traffic_light.is_set(None) does not comply in SensorView.global_ground_truth
+    [0, 2717]                                 GroundTruth.road_marking.is_set(None) does not comply in SensorView.global_ground_truth
+
+Next the path ``GroundTruth.environmental_conditions`` is set but not valid leading to the output below (Note that the indentation demonstrates the hierarchy of the message fields):
+
+.. code-block:: bash
+
+    [0, 2717]                                 GroundTruth.environmental_conditions.is_valid(None) does not comply in SensorView.
+        [0, 2717]                                 EnvironmentalConditions.atmospheric_pressure.is_greater_than_or_equal_to(80000) does not comply in SensorView.global_ground_truth.environmental_conditions.atmospheric_pressure
+        [0, 2717]                                 EnvironmentalConditions.temperature.is_greater_than_or_equal_to(170) does not comply in SensorView.global_ground_truth.environmental_conditions.temperature
+        [0, 2717]                                 EnvironmentalConditions.unix_timestamp.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+        [0, 498], [500, 998], [1000, 1498],       EnvironmentalConditions.fog.is_set(None) does not comply in SensorView.global_ground_truth.environmental_conditions
+        [1500, 1998], [2000, 2498], [2500, 2716]
+
+The output is generate because of the rules defined in ``osi_environment.yml``:
+
+.. code-block:: yaml
+
+    EnvironmentalConditions:
+        ambient_illumination:
+        time_of_day:
+        unix_timestamp:
+        atmospheric_pressure:
+            - is_greater_than_or_equal_to: 80000
+            - is_less_than_or_equal_to: 120000
+        temperature:
+            - is_greater_than_or_equal_to: 170
+            - is_less_than_or_equal_to: 340
+        relative_humidity:
+            - is_greater_than_or_equal_to: 0
+            - is_less_than_or_equal_to: 100
+        precipitation:
+        fog:
+        TimeOfDay:
+            seconds_since_midnight:
+            - is_greater_than_or_equal_to: 0
+            - is_less_than: 86400
+
+The rules state that the ``EnvironmentalConditions.atmospheric_pressure`` should be between 80000 Pa and 120000 Pa which is not the case for the trace (the used trace atmospheric_pressure is set to zero). 
+The same goes for the temprature.
+
+The validation output reads for the other fields the same way as for the example above (indentation and ordering was added manually for readability):
+
+.. code-block:: bash
+
+    [0, 2717]                                 GroundTruth.lane_boundary.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary
+        [0, 2717]                                 LaneBoundary.classification.is_valid(None) does not comply in SensorView.global_ground_truth.lane_boundary.classification
+            [0, 2717]                                 LaneBoundary.Classification.limiting_structure_id.is_set(None) does not comply in SensorView.global_ground_truth.lane_boundary.classification
+    [0, 2717]                                 GroundTruth.lane.is_valid(None) does not comply in SensorView.global_ground_truth.lane
+        [0, 2717]                                 Lane.classification.is_valid(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.right_adjacent_lane_id.check_if.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.right_adjacent_lane_id.check_if([{'is_different_to': 4, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.right_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.free_lane_boundary_id.check_if.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.free_lane_boundary_id.check_if([{'is_different_to': 4, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.free_lane_boundary_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.lane_pairing.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.left_adjacent_lane_id.check_if.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.left_adjacent_lane_id.check_if([{'is_different_to': 4, 'target': 'this.type'}]) does not comply in SensorView.global_ground_truth.lane.classification
+            [0, 2717]                                 Lane.Classification.left_adjacent_lane_id.is_set(None) does not comply in SensorView.global_ground_truth.lane.classification
+    [0, 2717]                                 GroundTruth.moving_object.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object
+        [0, 2717]                                 MovingObject.vehicle_attributes.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_attributes
+            [0, 2717]                                 MovingObject.VehicleAttributes.number_wheels.is_greater_than_or_equal_to(1) does not comply in SensorView.global_ground_truth.moving_object.vehicle_attributes.number_wheels
+        [0, 2717]                                 MovingObject.base.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.base
+            [0, 2717]                                 BaseMoving.orientation_acceleration.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+            [0, 2717]                                 BaseMoving.base_polygon.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.base
+        [0, 2717]                                 MovingObject.vehicle_classification.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification
+            [0, 2717]                                 MovingObject.VehicleClassification.LightState.emergency_vehicle_illumination.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification.light_state
+            [0, 2717]                                 MovingObject.VehicleClassification.light_state.is_valid(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification.light_state
+                [0, 2717]                                 MovingObject.VehicleClassification.LightState.service_vehicle_illumination.is_set(None) does not comply in SensorView.global_ground_truth.moving_object.vehicle_classification.light_state
+        [0, 2717]                                 MovingObject.model_reference.is_set(None) does not comply in SensorView.global_ground_truth.moving_object
+    [0, 2717]                                 GroundTruth.stationary_object.is_valid(None) does not comply in SensorView.global_ground_truth.stationary_object
+        [0, 2717]                                 StationaryObject.model_reference.is_set(None) does not comply in SensorView.global_ground_truth.stationary_object
+        [0, 2717]                                 StationaryObject.base.is_valid(None) does not comply in SensorView.global_ground_truth.stationary_object.base
+            [0, 2717]                                 BaseStationary.base_polygon.is_set(None) does not comply in SensorView.global_ground_truth.stationary_object.base
+
+Custom Rules
+--------------
+
+Currently the rules below exist:
+
+.. code-block:: python
+    
+    is_greater_than: 1
+    is_greater_than_or_equal_to: 1
+    is_less_than_or_equal_to: 10
+    is_less_than: 2
+    is_equal: 1
+    is_different: 2
+    is_globally_unique
+    refers_to: MovingObject
+    is_iso_country_code:
+    first_element: {is_equal: 0.13, is_greater_than: 0.13}
+    last_element: {is_equal: 0.13, is_greater_than: 0.13}
+    check_if: [{is_equal: 2, is_greater_than: 3, target: this.y}, {do_check: {is_equal: 1, is_less_than: 3}}]
+
+These rules can be added manually to the rules \*.yml files like in the example of the environmental conditions below (see :ref:`how-to-write-rules` for more): 
+
+.. code-block:: yaml
+
+    EnvironmentalConditions:
+        ambient_illumination:
+        time_of_day:
+        unix_timestamp:
+        atmospheric_pressure:
+            - is_greater_than_or_equal_to: 80000
+            - is_less_than_or_equal_to: 120000
+        temperature:
+            - is_greater_than_or_equal_to: 170
+            - is_less_than_or_equal_to: 340
+        relative_humidity:
+            - is_greater_than_or_equal_to: 0
+            - is_less_than_or_equal_to: 100
+        precipitation:
+        fog:
+        TimeOfDay:
+            seconds_since_midnight:
+            - is_greater_than_or_equal_to: 0
+            - is_less_than: 86400

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -267,6 +267,7 @@ This is because at least one message field does not comply to the rules like:
 
     [0, 498], [500, 998], [1000, 1498],       GroundTruth.country_code.is_set(None) does not comply in SensorView.global_ground_truth
     [1500, 1998], [2000, 2498], [2500, 2716]
+    499, 999, 1499, 1999, 2499, 2717          GroundTruth.country_code.is_iso_country_code(None) does not comply in SensorView.global_ground_truth.country_code
 
 In the rules (``osi_groundtruth.yml``) we defined (\*.yml files follow the same structure as \*.proto file in OSI):
 
@@ -276,7 +277,9 @@ In the rules (``osi_groundtruth.yml``) we defined (\*.yml files follow the same 
         country_code:
             - is_iso_country_code:
 
-This means if the field is not in the `ISO country code <https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes>`_ format an error will be thrown making ``SensorView.global_ground_truth`` invalid because ``SensorView.global_ground_truth.country_code`` is not set correctly. The incorrectness is appearing in the intervals between message frame 0 and message frame 498 but not in message frame 499. That is why you see split frame messages like this [0, 498], [500, 998].
+This means if the field is not in the `ISO country code <https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes>`_ format an error will be thrown making ``SensorView.global_ground_truth`` invalid because ``SensorView.global_ground_truth.country_code`` is not set. 
+The incorrectness is appearing in the intervals between message frame 0 and message frame 498 but not in message frame 499. In the message frame 499 the ``GroundTruth.country_code`` is set but do not comply to the ``is_iso_country_code`` rule. 
+That is why you see split frame messages like this [0, 498], [500, 998] for not set and 499 for is not ISO country code.
 Note that ``GroundTruth.country_code`` refers to the same path as ``SensorView.global_ground_truth.country_code``. 
 The SensorView part is cut due to better readability.
 
@@ -367,7 +370,7 @@ The validation output reads for the other fields the same way as for the example
 Custom Rules
 --------------
 
-Currently the rules below exist:
+Currently the following rules exist:
 
 .. code-block:: python
     
@@ -407,3 +410,5 @@ These rules can be added manually to the rules \*.yml files like in the example 
             seconds_since_midnight:
             - is_greater_than_or_equal_to: 0
             - is_less_than: 86400
+
+Further custom rules can be implemented into the osi-validator (see `rules implementation <https://opensimulationinterface.github.io/osi-documentation/osi-validation/doc/osivalidator.html#module-osivalidator.osi_rules_implementations>`_ for more).

--- a/doc/writing-rules.rst
+++ b/doc/writing-rules.rst
@@ -41,7 +41,6 @@ The rules can either be with or without any parameters.
 ::
 
   is_greater_than_or_equal_to: 0.0
-  is_optional
   is_equal: 1
 
 In the case a rule has a parameter, it is written as a `mapping` ( a `scalar`
@@ -57,12 +56,11 @@ The available rules and their usage are explained in the osi-validator class `os
     is_less_than: 2
     is_equal: 1
     is_different: 2
-    is_global_unique
-    refers
-    is_iso_country_code
+    is_globally_unique
+    refers_to: Lane
+    is_iso_country_code:
     first_element: {is_equal: 0.13, is_greater_than: 0.13}
     last_element: {is_equal: 0.13, is_greater_than: 0.13}
-    is_optional
     check_if: [{is_equal: 2, is_greater_than: 3, target: this.y}, {do_check: {is_equal: 1, is_less_than: 3}}]
 
 

--- a/osivalidator/osi_general_validator.py
+++ b/osivalidator/osi_general_validator.py
@@ -138,11 +138,7 @@ def main():
     # Read data
     print("Reading data ...")
     DATA = OSITrace(buffer_size=args.buffer)
-    DATA.from_file(
-        path=args.data,
-        type_name=args.type,
-        max_index=args.timesteps
-    )
+    DATA.from_file(path=args.data, type_name=args.type, max_index=args.timesteps)
 
     # Collect Validation Rules
     print("Collect validation rules ...")

--- a/osivalidator/osi_general_validator.py
+++ b/osivalidator/osi_general_validator.py
@@ -141,8 +141,7 @@ def main():
     DATA.from_file(
         path=args.data,
         type_name=args.type,
-        max_index=args.timesteps,
-        format_type=args.format,
+        max_index=args.timesteps
     )
 
     # Collect Validation Rules

--- a/osivalidator/osi_trace.py
+++ b/osivalidator/osi_trace.py
@@ -42,9 +42,7 @@ MESSAGES_TYPE = {
 class OSITrace:
     """This class wrap OSI data. It can import and decode OSI traces."""
 
-    def __init__(
-        self, buffer_size, show_progress=True, type_name="SensorView"
-    ):
+    def __init__(self, buffer_size, show_progress=True, type_name="SensorView"):
         self.trace_file = None
         self.message_offsets = None
         self.buffer_size = buffer_size
@@ -334,7 +332,9 @@ class OSITrace:
                 yield LinkedProtoField(message, name=self.type_name)
 
         else:
-            raise Exception(f"The defined file format {self.path.split('/')[-1]} does not exist.")
+            raise Exception(
+                f"The defined file format {self.path.split('/')[-1]} does not exist."
+            )
 
         if self.show_progress:
             self.update_bar(progress_bar, progress_bar.max)

--- a/osivalidator/osi_trace.py
+++ b/osivalidator/osi_trace.py
@@ -43,7 +43,7 @@ class OSITrace:
     """This class wrap OSI data. It can import and decode OSI traces."""
 
     def __init__(
-        self, buffer_size, show_progress=True, path=None, type_name="SensorView"
+        self, buffer_size, show_progress=True, type_name="SensorView"
     ):
         self.trace_file = None
         self.message_offsets = None
@@ -57,17 +57,17 @@ class OSITrace:
         self.retrieved_trace_size = 0
 
     # Open and Read text file
-    def from_file(self, path, type_name="SensorView", max_index=-1, format_type=None):
+    def from_file(self, path, type_name="SensorView", max_index=-1):
         """Import a trace from a file"""
-        if path.lower().endswith((".lzma", ".xz")):
-            self.trace_file = lzma.open(path, "rb")
+        self.path = path
+        if self.path.lower().endswith((".lzma", ".xz")):
+            self.trace_file = lzma.open(self.path, "rb")
         else:
-            self.trace_file = open(path, "rb")
+            self.trace_file = open(self.path, "rb")
 
         self.type_name = type_name
-        self.format_type = format_type
 
-        if self.format_type == "separated":
+        if self.path.lower().endswith((".txt.lzma", ".txt.xz", ".txt")):
             warnings.warn(
                 "The separated trace files will be completely removed in the near future. Please convert them to *.osi files with the converter in the main OSI repository.",
                 PendingDeprecationWarning,
@@ -297,7 +297,7 @@ class OSITrace:
             for abs_message_offset in self.message_offsets[begin:end]
         ]
 
-        if self.format_type == "separated":
+        if self.path.lower().endswith((".txt.lzma", ".txt.xz", ".txt")):
             message_sequence_len = abs_last_offset - abs_first_offset - SEPARATOR_LENGTH
             serialized_messages_extract = self.trace_file.read(message_sequence_len)
 
@@ -315,7 +315,7 @@ class OSITrace:
                 self.update_bar(progress_bar, rel_index)
                 yield LinkedProtoField(message, name=self.type_name)
 
-        elif self.format_type is None:
+        elif self.path.lower().endswith((".osi.lzma", ".osi.xz", ".osi")):
             message_sequence_len = abs_last_offset - abs_first_offset
             serialized_messages_extract = self.trace_file.read(message_sequence_len)
 
@@ -334,7 +334,7 @@ class OSITrace:
                 yield LinkedProtoField(message, name=self.type_name)
 
         else:
-            raise Exception(f"The defined format {self.format_type} does not exist.")
+            raise Exception(f"The defined file format {self.path.split('/')[-1]} does not exist.")
 
         if self.show_progress:
             self.update_bar(progress_bar, progress_bar.max)

--- a/requirements-osi-3/osi_common.yml
+++ b/requirements-osi-3/osi_common.yml
@@ -2,11 +2,15 @@ Vector3d:
   x:
   y:
   z:
-
 Vector2d:
   x:
   y:
-
+Timestamp:
+  seconds:
+    - is_greater_than_or_equal_to: 0
+  nanos:
+    - is_greater_than_or_equal_to: 0
+    - is_less_than_or_equal_to: 999999999
 Dimension3d:
   length:
     - is_greater_than_or_equal_to: 0
@@ -14,29 +18,26 @@ Dimension3d:
     - is_greater_than_or_equal_to: 0
   height:
     - is_greater_than_or_equal_to: 0
-
 Orientation3d:
   roll:
   pitch:
   yaw:
-
+Identifier:
+  value:
+    - is_greater_than_or_equal_to: 0
 MountingPosition:
   position:
   orientation:
-
 Spherical3d:
   distance:
     - is_greater_than_or_equal_to: 0
   azimuth:
   elevation:
-
 BaseStationary:
   dimension:
   position:
   orientation:
   base_polygon:
-    #- is_set
-
 BaseMoving:
   dimension:
   position:
@@ -45,16 +46,4 @@ BaseMoving:
   acceleration:
   orientation_rate:
   orientation_acceleration:
-    #- is_set
   base_polygon:
-    #- is_set
-
-Identifier:
-  value:
-    - is_greater_than_or_equal_to: 0
-Timestamp:
-  seconds:
-    - is_greater_than_or_equal_to: 0
-  nanos:
-    - is_greater_than_or_equal_to: 0
-    - is_less_than_or_equal_to: 999999999

--- a/requirements-osi-3/osi_datarecording.yml
+++ b/requirements-osi-3/osi_datarecording.yml
@@ -1,4 +1,4 @@
 SensorDataSeries:
-  
+  sensor_data:
 SensorDataSeriesList:
-  
+  sensor:

--- a/requirements-osi-3/osi_detectedlane.yml
+++ b/requirements-osi-3/osi_detectedlane.yml
@@ -1,12 +1,21 @@
 DetectedLane:
   header:
+  candidate:
   CandidateLane:
+    probability:
+      - is_less_than_or_equal_to: 1
+      - is_greater_than_or_equal_to: 0
+    classification:
+DetectedLaneBoundary:
+  header:
+  candidate:
+  boundary_line:
+  boundary_line_rmse:
+  boundary_line_confidences:
+    - is_greater_than_or_equal_to: 0
+    - is_less_than_or_equal_to: 1
+  CandidateLaneBoundary:
     probability:
       - is_greater_than_or_equal_to: 0
       - is_less_than_or_equal_to: 1
     classification:
-
-DetectedLaneBoundary:
-  header:
-  boundary_line:
-    position:

--- a/requirements-osi-3/osi_detectedobject.yml
+++ b/requirements-osi-3/osi_detectedobject.yml
@@ -6,20 +6,21 @@ DetectedItemHeader:
     - is_less_than_or_equal_to: 1
   age:
   measurement_state:
-  
+  sensor_id:
 DetectedStationaryObject:
   header:
   base:
-  base_rsme:
+  base_rmse:
+  candidate:
   CandidateStationaryObject:
     probability:
       - is_greater_than_or_equal_to: 0
       - is_less_than_or_equal_to: 1
-
+    classification:
 DetectedMovingObject:
   header:
   base:
-  base_rsme:
+  base_rmse:
   reference_point:
   movement_state:
   percentage_side_lane_left:
@@ -28,10 +29,11 @@ DetectedMovingObject:
   percentage_side_lane_right:
     - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 100
-  radar_specifics: # TODO
-  lidar_specifics: # TODO
-  camera_specifics: # TODO
-  ultrasonic_specifics: # TODO
+  candidate:
+  radar_specifics:
+  lidar_specifics:
+  camera_specifics:
+  ultrasonic_specifics:
   CandidateMovingObject:
     probability:
       - is_greater_than_or_equal_to: 0

--- a/requirements-osi-3/osi_detectedoccupant.yml
+++ b/requirements-osi-3/osi_detectedoccupant.yml
@@ -5,3 +5,4 @@ DetectedOccupant:
     probability:
       - is_greater_than_or_equal_to: 0
       - is_less_than_or_equal_to: 1
+    classification:

--- a/requirements-osi-3/osi_detectedroadmarking.yml
+++ b/requirements-osi-3/osi_detectedroadmarking.yml
@@ -1,8 +1,10 @@
 DetectedRoadMarking:
   header:
   base:
-  base_rsme:
+  base_rmse:
+  candidate:
   CandidateRoadMarking:
     probability:
-      - is_greater_than_or_equal_to: 0
       - is_less_than_or_equal_to: 1
+      - is_greater_than_or_equal_to: 0
+    classification:

--- a/requirements-osi-3/osi_detectedtrafficlight.yml
+++ b/requirements-osi-3/osi_detectedtrafficlight.yml
@@ -1,9 +1,10 @@
 DetectedTrafficLight:
   header:
   base:
-  base_rsme:
+  base_rmse:
+  candidate:
   CandidateTrafficLight:
-    color: 
     probability:
-      - is_greater_than_or_equal_to: 0
       - is_less_than_or_equal_to: 1
+      - is_greater_than_or_equal_to: 0
+    classification:

--- a/requirements-osi-3/osi_detectedtrafficsign.yml
+++ b/requirements-osi-3/osi_detectedtrafficsign.yml
@@ -1,18 +1,23 @@
 DetectedTrafficSign:
   header:
   main_sign:
+  supplementary_sign:
   DetectedMainSign:
+    candidate:
     base:
-    base_rsme:
+    base_rmse:
     geometry:
     CandidateMainSign:
       probability:
-        - is_greater_than_or_equal_to: 0
         - is_less_than_or_equal_to: 1
+        - is_greater_than_or_equal_to: 0
+      classification:
   DetectedSupplementarySign:
+    candidate:
     base:
-    base_rsme:
+    base_rmse:
     CandidateSupplementarySign:
       probability:
-        - is_greater_than_or_equal_to: 0
         - is_less_than_or_equal_to: 1
+        - is_greater_than_or_equal_to: 0
+      classification:

--- a/requirements-osi-3/osi_environment.yml
+++ b/requirements-osi-3/osi_environment.yml
@@ -1,6 +1,7 @@
 EnvironmentalConditions:
   ambient_illumination:
   time_of_day:
+  unix_timestamp:
   atmospheric_pressure:
     - is_greater_than_or_equal_to: 80000
     - is_less_than_or_equal_to: 120000

--- a/requirements-osi-3/osi_featuredata.yml
+++ b/requirements-osi-3/osi_featuredata.yml
@@ -1,5 +1,9 @@
 FeatureData:
   version:
+  radar_sensor:
+  lidar_sensor:
+  ultrasonic_sensor:
+  camera_sensor:
 SensorDetectionHeader:
   measurement_time:
   cycle_counter:
@@ -7,14 +11,13 @@ SensorDetectionHeader:
   mounting_position:
   mounting_position_rmse:
   data_qualifier:
-  number_of_valid_detection:
+  number_of_valid_detections:
     - is_greater_than_or_equal_to: 0
   sensor_id:
-
+  extended_qualifier:
 RadarDetectionData:
   header:
   detection:
-
 RadarDetection:
   existence_probability:
     - is_greater_than_or_equal_to: 0
@@ -32,11 +35,11 @@ RadarDetection:
   point_target_probability:
     - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 1
-  ambiguity_id: # TODO
-
+  ambiguity_id:
+  classification:
 LidarDetectionData:
   header:
-
+  detection:
 LidarDetection:
   existence_probability:
     - is_greater_than_or_equal_to: 0
@@ -55,11 +58,16 @@ LidarDetection:
   free_space_probability:
     - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 1
-  reflectivity: # TODO
-
+  classification:
+  reflectivity:
+UltrasonicDetectionSpecificHeader:
+  max_range:
+  number_of_valid_indirect_detections:
 UltrasonicDetectionData:
   header:
-
+  specific_header:
+  detection:
+  indirect_detection:
 UltrasonicDetection:
   existence_probability:
     - is_greater_than_or_equal_to: 0
@@ -68,7 +76,6 @@ UltrasonicDetection:
     - refers_to: DetectedObject
   distance:
     - is_greater_than_or_equal_to: 0
-
 UltrasonicIndirectDetection:
   existence_probability:
     - is_greater_than_or_equal_to: 0
@@ -79,33 +86,55 @@ UltrasonicIndirectDetection:
   ellipsoid_axial:
   receiver_id:
   receiver_origin:
-
 CameraDetectionSpecificHeader:
   number_of_valid_points:
     - is_greater_than_or_equal_to: 0
-
 CameraDetectionData:
   header:
   specific_header:
   detection:
-
+  point:
 CameraDetection:
-  existence_probability: 
+  existence_probability:
     - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 1
   object_id:
     - refers_to: DetectedObject
   time_difference:
   image_shape_type:
+  shape_classification_background:
+  shape_classification_foreground:
+  shape_classification_flat:
+  shape_classification_upright:
+  shape_classification_ground:
+  shape_classification_sky:
+  shape_classification_vegetation:
+  shape_classification_road:
+  shape_classification_non_driving_lane:
+  shape_classification_non_road:
+  shape_classification_stationary_object:
+  shape_classification_moving_object:
+  shape_classification_landmark:
+  shape_classification_traffic_sign:
+  shape_classification_traffic_light:
+  shape_classification_road_marking:
+  shape_classification_vehicle:
+  shape_classification_pedestrian:
+  shape_classification_animal:
+  shape_classification_pedestrian_front:
+  shape_classification_pedestrian_side:
+  shape_classification_pedestrian_rear:
   shape_classification_probability:
     - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 1
+  color:
   color_probability:
     - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 1
+  ambiguity_id:
+  first_point_index:
   number_of_points:
     - is_greater_than_or_equal_to: 0
-
 CameraPoint:
   existence_probability:
     - is_greater_than_or_equal_to: 0

--- a/requirements-osi-3/osi_groundtruth.yml
+++ b/requirements-osi-3/osi_groundtruth.yml
@@ -3,6 +3,16 @@ GroundTruth:
   timestamp:
   host_vehicle_id:
     - refers_to: MovingObject
+  stationary_object:
+  moving_object:
+  traffic_sign:
+  traffic_light:
+  road_marking:
+  lane_boundary:
+  lane:
+  occupant:
   environmental_conditions:
   country_code:
     - is_iso_country_code:
+  proj_string:
+  map_reference:

--- a/requirements-osi-3/osi_lane.yml
+++ b/requirements-osi-3/osi_lane.yml
@@ -5,6 +5,8 @@ Lane:
   Classification:
     type:
     is_host_vehicle_lane:
+    centerline:
+    centerline_is_driving_direction:
     left_adjacent_lane_id:
       - check_if:
         - is_different_to: 4
@@ -17,6 +19,7 @@ Lane:
           target: this.type
         do_check:
         - is_set:
+    lane_pairing:
     right_lane_boundary_id:
       - check_if:
         - is_different_to: 4
@@ -36,11 +39,6 @@ Lane:
         do_check:
         - is_set:
     road_condition:
-    LanePairing:
-      antecessor_lane_id:
-        - refers_to: Lane
-      successor_lane_id:
-        - refers_to: Lane
     RoadCondition:
       surface_temperature:
         - is_greater_than_or_equal_to: 0
@@ -53,30 +51,34 @@ Lane:
       surface_roughness:
         - is_greater_than_or_equal_to: 0
       surface_texture:
+    LanePairing:
+      antecessor_lane_id:
+        - refers_to: Lane
+      successor_lane_id:
+        - refers_to: Lane
 LaneBoundary:
   id:
     - is_globally_unique:
   boundary_line:
+    - first_element:
+        width:
+          - is_equal_to: 0.13
+    - first_element:
+        height:
+          - is_equal_to: 0.13
     - last_element:
         width:
           - is_equal_to: 0.13
-
+    - last_element:
         height:
           - is_equal_to: 0.13
-
-    - first_element:
-        width:
-            - is_equal_to: 0.14
-
-        height:
-            - is_equal_to: 0.13
-
   classification:
   BoundaryPoint:
     position:
+    width:
+    height:
   Classification:
     type:
     color:
     limiting_structure_id:
       - refers_to: StationaryObject
-    

--- a/requirements-osi-3/osi_object.yml
+++ b/requirements-osi-3/osi_object.yml
@@ -3,12 +3,12 @@ StationaryObject:
     - is_globally_unique:
   base:
   classification:
+  model_reference:
   Classification:
     type:
     material:
     density:
     color:
-
 MovingObject:
   id:
     - is_globally_unique:
@@ -27,35 +27,26 @@ MovingObject:
         target: this.type
       do_check:
       - is_set:
-
+  model_reference:
   VehicleAttributes:
-    driver_id: # TODO: is set only if host_vehicle is false or use value for non valid id
-      - check_if:
-        - is_set:
-          target: parent.parent.host_vehicle_id
-        do_check:
-        - is_set:
-    
+    driver_id:
     radius_wheel:
       - is_greater_than_or_equal_to: 0
-    number_wheel:
+    number_wheels:
       - is_greater_than_or_equal_to: 1
     bbcenter_to_rear:
     bbcenter_to_front:
     ground_clearance:
-  
   VehicleClassification:
     type:
     light_state:
     has_trailer:
     trailer_id:
-      - is_optional:
       - check_if:
         - is_equal_to: true
           target: this.has_trailer
         do_check:
         - is_set:
-    
     LightState:
       indicator_state:
       front_fog_light:
@@ -66,6 +57,4 @@ MovingObject:
       brake_light_state:
       license_plate_illumination_rear:
       emergency_vehicle_illumination:
-        #- is_set
       service_vehicle_illumination:
-        #- is_set

--- a/requirements-osi-3/osi_occupant.yml
+++ b/requirements-osi-3/osi_occupant.yml
@@ -6,4 +6,3 @@ Occupant:
     is_driver:
     seat:
     steering_control:
-      

--- a/requirements-osi-3/osi_roadmarking.yml
+++ b/requirements-osi-3/osi_roadmarking.yml
@@ -1,15 +1,16 @@
 RoadMarking:
   id:
-    - is_globally_unique:
   base:
   classification:
   Classification:
     type:
     traffic_main_sign_type:
-      - is_optional:
       - check_if:
         - is_greater_than_or_equal_to: 2
           target: this.type
+        do_check:
+        - is_set:
+      - check_if:
         - is_less_than_or_equal_to: 4
           target: this.type
         do_check:
@@ -25,8 +26,8 @@ RoadMarking:
           target: this.monochrome_color
         do_check:
         - is_set:
-    value: # TODO: when is it necessary to put a value?
-    value_text: # TODO: when is it necessary to put a value?
+    value:
+    value_text:
     assigned_lane_id:
       - refers_to: Lane
     is_out_of_service:

--- a/requirements-osi-3/osi_sensordata.yml
+++ b/requirements-osi-3/osi_sensordata.yml
@@ -2,12 +2,30 @@ DetectedEntityHeader:
   measurement_time:
   cycle_counter:
   data_qualifier:
-
 SensorData:
   version:
   timestamp:
+  host_vehicle_location:
+  host_vehicle_location_rmse:
   sensor_id:
   mounting_position:
   mounting_position_rmse:
   sensor_view:
-# TODO: rules for the other attributes?
+  last_measurement_time:
+  stationary_object_header:
+  stationary_object:
+  moving_object_header:
+  moving_object:
+  traffic_sign_header:
+  traffic_sign:
+  traffic_light_header:
+  traffic_light:
+  road_marking_header:
+  road_marking:
+  lane_boundary_header:
+  lane_boundary:
+  lane_header:
+  lane:
+  occupant_header:
+  occupant:
+  feature_data:

--- a/requirements-osi-3/osi_sensorspecific.yml
+++ b/requirements-osi-3/osi_sensorspecific.yml
@@ -1,13 +1,16 @@
 RadarSpecificObjectData:
   rcs:
-
-
+LidarSpecificObjectData:
+CameraSpecificObjectData:
 UltrasonicSpecificObjectData:
   maximum_measurement_distance_sensor:
     - is_greater_than_or_equal_to: 0
   probability:
-    - is_greater_than_or_equal_to: 0
     - is_less_than_or_equal_to: 1
+    - is_greater_than_or_equal_to: 0
   trilateration_status:
   trend:
   signalway:
+  Signalway:
+    sender_id:
+    receiver_id:

--- a/requirements-osi-3/osi_sensorview.yml
+++ b/requirements-osi-3/osi_sensorview.yml
@@ -9,3 +9,33 @@ SensorView:
   global_ground_truth:
   host_vehicle_id:
     - refers_to: 'MovingObject'
+  generic_sensor_view:
+  radar_sensor_view:
+  lidar_sensor_view:
+  camera_sensor_view:
+  ultrasonic_sensor_view:
+GenericSensorView:
+  view_configuration:
+RadarSensorView:
+  view_configuration:
+  reflection:
+  Reflection:
+    signal_strength:
+    time_of_flight:
+    doppler_shift:
+    source_horizontal_angle:
+    source_vertical_angle:
+LidarSensorView:
+  view_configuration:
+  reflection:
+  Reflection:
+    signal_strength:
+    time_of_flight:
+    doppler_shift:
+    normal_to_surface:
+    object_id:
+CameraSensorView:
+  view_configuration:
+  image_data:
+UltrasonicSensorView:
+  view_configuration:

--- a/requirements-osi-3/osi_sensorviewconfiguration.yml
+++ b/requirements-osi-3/osi_sensorviewconfiguration.yml
@@ -10,14 +10,17 @@ SensorViewConfiguration:
   update_cycle_time:
   update_cycle_offset:
   simulation_start_time:
-  
+  generic_sensor_view_configuration:
+  radar_sensor_view_configuration:
+  lidar_sensor_view_configuration:
+  camera_sensor_view_configuration:
+  ultrasonic_sensor_view_configuration:
 GenericSensorViewConfiguration:
   sensor_id:
   mounting_position:
   mounting_position_rmse:
   field_of_view_horizontal:
   field_of_view_vertical:
-
 RadarSensorViewConfiguration:
   sensor_id:
   mounting_position:
@@ -38,7 +41,6 @@ RadarSensorViewConfiguration:
     horizontal_angle:
     vertical_angle:
     response:
-
 LidarSensorViewConfiguration:
   sensor_id:
   mounting_position:
@@ -55,7 +57,8 @@ LidarSensorViewConfiguration:
     - is_greater_than_or_equal_to: 0
   num_of_pixels:
     - is_greater_than_or_equal_to: 1
-  
+  directions:
+  timings:
 CameraSensorViewConfiguration:
   sensor_id:
   mounting_position:
@@ -68,8 +71,6 @@ CameraSensorViewConfiguration:
     - is_greater_than_or_equal_to: 1
   channel_format:
     - is_greater_than_or_equal_to: 1
-
-
 UltrasonicSensorViewConfiguration:
   sensor_id:
   mounting_position:

--- a/requirements-osi-3/osi_trafficlight.yml
+++ b/requirements-osi-3/osi_trafficlight.yml
@@ -9,6 +9,6 @@ TrafficLight:
     mode:
     counter:
       - is_greater_than_or_equal_to: 0
-    assigned_line_id:
+    assigned_lane_id:
       - refers_to: Lane
     is_out_of_service:

--- a/requirements-osi-3/osi_trafficsign.yml
+++ b/requirements-osi-3/osi_trafficsign.yml
@@ -1,32 +1,34 @@
 TrafficSignValue:
   value:
   value_unit:
-
+  text:
 TrafficSign:
   id:
     - is_globally_unique:
   main_sign:
+  supplementary_sign:
   MainSign:
     base:
     classification:
     Classification:
       variability:
       type:
-      value: # TODO: does not require it?
+      value:
+      direction_scope:
       assigned_lane_id:
         - refers_to: Lane
       vertically_mirrored:
-      is_out_of_service:
-
   SupplementarySign:
     base:
     classification:
     Classification:
       variability:
       type:
-      value: # TODO: does not require it?
+      value:
       assigned_lane_id:
         - refers_to: Lane
+      actor:
+      arrow:
       is_out_of_service:
       Arrow:
         lane_id:

--- a/requirements-osi-3/osi_version.yml
+++ b/requirements-osi-3/osi_version.yml
@@ -2,3 +2,4 @@ InterfaceVersion:
   version_major:
   version_minor:
   version_patch:
+  current_interface_version:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
 
     setuptools.setup(
         name="osivalidator",
-        version="0.5",
+        version="1.0.0",
         author=AUTHOR,
         description="Validator for OSI messages",
         long_description=README,

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -2,6 +2,7 @@
 
 import unittest
 from osivalidator.osi_trace import OSITrace
+import subprocess
 
 
 class TestDataContainer(unittest.TestCase):
@@ -17,8 +18,11 @@ class TestDataContainer(unittest.TestCase):
         self.txt.from_file(
             path="data/small_test.txt.lzma",
             type_name="SensorView",
-            format_type="separated",
         )
+        subprocess.call(["lzma", "-d", "data/small_test.txt.lzma"])
+        subprocess.call(["python3", "open-simulation-interface/format/txt2osi.py", "-d", "data/small_test.txt"])
+        subprocess.call(["lzma", "-z", "data/small_test.osi"])
+        subprocess.call(["lzma", "-z", "data/small_test.txt"])
         self.osi.from_file(path="data/small_test.osi.lzma", type_name="SensorView")
         self.osi_nobuffer.from_file(
             path="data/small_test.osi.lzma", type_name="SensorView"
@@ -33,6 +37,9 @@ class TestDataContainer(unittest.TestCase):
 
         self.osi_nobuffer.trace_file.close()
         del self.osi_nobuffer
+
+        subprocess.call(["rm", "data/small_test.osi.lzma"])
+        subprocess.call(["rm", "data/small_test.osi"])
 
     def test_get_messages_in_index_range(self):
         """Test getting messages in range"""

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -16,11 +16,17 @@ class TestDataContainer(unittest.TestCase):
         self.osi_nobuffer = OSITrace(buffer_size=0)
 
         self.txt.from_file(
-            path="data/small_test.txt.lzma",
-            type_name="SensorView",
+            path="data/small_test.txt.lzma", type_name="SensorView",
         )
         subprocess.call(["lzma", "-d", "data/small_test.txt.lzma"])
-        subprocess.call(["python3", "open-simulation-interface/format/txt2osi.py", "-d", "data/small_test.txt"])
+        subprocess.call(
+            [
+                "python3",
+                "open-simulation-interface/format/txt2osi.py",
+                "-d",
+                "data/small_test.txt",
+            ]
+        )
         subprocess.call(["lzma", "-z", "data/small_test.osi"])
         subprocess.call(["lzma", "-z", "data/small_test.txt"])
         self.osi.from_file(path="data/small_test.osi.lzma", type_name="SensorView")


### PR DESCRIPTION
#### Reference to a related issue in the repository
No issue!

#### Add a description
This PR is an update to the validator usage and the usage documentation.

Change notes:
- Improved code snippets formats in the setup.rst/usage.rst
- Unit test on trace file is independet of travis CI (self contained with file handling)
- Removed the format option (-f separated) from the validator call instead it just detects the trace file extension automatically
- Updated travis CI according to the change above
- Added (venv) into the README indicating the activation of the virtual environment
- Added an optional compilation step if users want only a binary file from the osi-validator in README.md and setup.rst
- Added a complex example for the interpretation of the validation output
- Updated writing-rules.rst with correct rules
- Updated the requirements-osi-3 folder with the official rules from OSI rules comments

#### Mention a member
@jdsika pls review and merge! Thanks!

#### Check the checklist

- [x] My code and comments follow the [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-validation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.