### PR TITLE
Fix wrong link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 
 > **_NOTE:_**  This tool is not part of the official OSI standard. It has its own release schedule. The OSI CCB is not responsible for this software but MUST be notified about pull requests.
 
-OSI Validator checks the compliance of OSI messages with predefined [rules](https://github.com/OpenSimulationInterface/osi-validation/tree/master/rules). The full documentation on the validator and customization of the rules is available [here](https://github.com/OpenSimulationInterface/osi-validation/tree/master/doc).
+OSI Validator checks the compliance of OSI messages with predefined rules.
+These rules can be generated from the OSI .proto files with [rules2yml.py](https://github.com/OpenSimulationInterface/osi-validation/blob/master/rules2yml.py).
+After the rules are generated, they can be customized by the user.
+The full documentation on the validator and customization of the rules is available [here](https://github.com/OpenSimulationInterface/osi-validation/tree/master/doc).
 
 ## Usage
 


### PR DESCRIPTION
#### Reference to a related issue in the repository
#63 

#### Add a description
Removed dead link in readme and added explanation about generating rules.

#### Mention a member
@raue 

#### Check the checklist

- [x] My code and comments follow the [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-validation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.