### PR TITLE
Automatically detect type from file name

### DIFF
--- a/osivalidator/osi_general_validator.py
+++ b/osivalidator/osi_general_validator.py
@@ -53,9 +53,8 @@ def command_line_arguments():
     parser.add_argument(
         "--type",
         "-t",
-        help="Name of the type used to serialize data.",
+        help="Name of the type used to serialize data. Default is SensorView.",
         choices=["SensorView", "GroundTruth", "SensorData"],
-        default="SensorView",
         type=str,
         required=False,
     )
@@ -122,11 +121,34 @@ LOGGER = osi_validator_logger.OSIValidatorLogger()
 VALIDATION_RULES = osi_rules.OSIRules()
 
 
+def detect_message_type(path: str):
+    """Automatically detect the message type from the file name.
+    If it cannot be detected, the function return SensorView as default.
+
+    Args:
+        path (str): Path incl. filename of the trace file
+
+    Returns:
+        Str: Message type as string, e.g. SensorData, SensorView etc.
+    """
+    filename = os.path.basename(path)
+    if filename.find("_sd_") != -1:
+        return "SensorData"
+    if filename.find("_sv_") != -1:
+        return "SensorView"
+    if filename.find("_gt_") != -1:
+        return "GroundTruth"
+    return "SensorView"
+
+
 def main():
     """Main method"""
 
     # Handling of command line arguments
     args = command_line_arguments()
+
+    if not args.type:
+        args.type = detect_message_type(args.data)
 
     # Instantiate Logger
     print("Instantiate logger ...")


### PR DESCRIPTION
#### Reference to a related issue in the repository
#72 

#### Add a description
Automatically detect top-level message type from file name, if no type is specified as an input argument. The default SensorView remains, if no type is set and no type can be detected.

#### Mention a member
@jdsika 

#### Check the checklist

- [x] My code and comments follow the [contributors guidelines](https://opensimulationinterface.github.io/osi-documentation/osi/howtocontribute.html) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-validation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.